### PR TITLE
fix: LinkSheet-launched apps not showing in Recents menu

### DIFF
--- a/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
+++ b/app/src/main/java/fe/linksheet/module/viewmodel/BottomSheetViewModel.kt
@@ -117,6 +117,7 @@ class BottomSheetViewModel(
     fun startPackageInfoActivity(context: Activity, info: ActivityAppInfo): Boolean {
         return context.startActivityWithConfirmation(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
             this.data = Uri.parse("package:${info.packageName}")
+            this.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         })
     }
 
@@ -247,6 +248,8 @@ class BottomSheetViewModel(
         if (persist && privateBrowsingBrowser == null && intent.data != null) {
             persistSelectedIntent(viewIntent, always)
         }
+
+        viewIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 
         return viewIntent
     }


### PR DESCRIPTION
I noticed an issue in the Nightly where opening a Bluesky link from Discord would forward me to Bluesky, but would still be in LinkSheet's task, meaning switching back to Discord (or another app) would clear LinkSheet, and therefore also Bluesky, from Recents.

This PR adds `FLAG_ACTIVITY_NEW_TASK` to the app launch Intent and also to the app settings Intent so that they launch outside of LinkSheet's task that's excluded from Recents.