### PR TITLE
Add IronFox Nightly to known browsers

### DIFF
--- a/features/browser/src/main/res/values/arrays.xml
+++ b/features/browser/src/main/res/values/arrays.xml
@@ -16,6 +16,7 @@
         <item>org.mozilla.reference.browser</item>
         <item>info.guardianproject.orfox</item>
         <item>org.ironfoxoss.ironfox</item>
+        <item>org.ironfoxoss.ironfox.nightly</item>
     </string-array>
     <string-array name="chromium">
         <item>com.android.chrome</item>


### PR DESCRIPTION
As of https://github.com/ironfox-oss/IronFox/commit/a2c7570bdc4dc824ec3b66f4ec12f9678cbe7de9, we're now using a separate package ID for Nightly builds.

Similar to https://github.com/LinkSheet/LinkSheet/pull/525, this adds IronFox Nightly to the list of known browsers.